### PR TITLE
If a message from a rabbit queue is not an array, make it into one

### DIFF
--- a/lib/GRNOC/NetSage/Deidentifier/FlowArchive.pm
+++ b/lib/GRNOC/NetSage/Deidentifier/FlowArchive.pm
@@ -80,7 +80,8 @@ sub _archive_flows {
     $self->_set_sensors( \%sensors );
 
     my $filepath = $path . "/" . $filename;
-    open my $fh, '>>', $filepath;
+    # 7/20/18 - open with encoding utf-8 to be able to deal with utf-8 in science registry info
+    open my $fh, '>>:encoding(utf-8)', $filepath;
     print $fh $self->json->encode( $input_data ) . "\n";
     close $fh;
 

--- a/lib/GRNOC/NetSage/Deidentifier/Pipeline.pm
+++ b/lib/GRNOC/NetSage/Deidentifier/Pipeline.pm
@@ -314,23 +314,9 @@ sub _consume_loop {
         # make sure its an array (ref) of messages
         if ( ref( $messages ) ne 'ARRAY' ) {
 
-            $self->logger->error( "Message body must be an array." );
+            # make it into a one-element array (needed for rabbit msgs written by logstash)
+            $messages = [$messages]
 
-
-            try {
-                # reject the message and do NOT requeue since it's not properly formed
-                $rabbit->reject( $input_channel, $delivery_tag, 0 );
-            }
-
-            catch {
-
-                $self->logger->error( "Unable to reject rabbit message: $_" );
-
-                # reconnect to rabbit since we had a failure
-                #$self->_rabbit_connect();
-            };
-
-            next;
         }
 
         my $num_messages = @$messages;


### PR DESCRIPTION
This is a reminder to include this change in the next version of the pipeline.
It was made as a local mod on netsage-archive.grnoc.iu.edu when trying to replace part of the pipeline with logstash. 
Logstash can read an array of flows out of rabbit but can't write an array TO rabbit; it pushes one message per flow into rabbit queues. However, when a pipeline module (incoming_flow_mover or flow_archiver, in particular) tried to read the those messages, they were discarded, since they were not arrays. 
Here, instead of discarding such messages, we change them into one-element arrays and proceed.
