### PR TITLE
Fix for when nfdump returns name for protocol instead of number

### DIFF
--- a/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
+++ b/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
@@ -384,7 +384,7 @@ my $path = $params{'path'};
             if( $pr =~ /^\d+$/ ) {
                 $proto = getprotobynumber( $pr );
             } else {
-                $proto = getprotobyname( lc($pr) );
+                $proto = lc($pr);
             }
 
             my $row = {};

--- a/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
+++ b/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
@@ -381,9 +381,9 @@ my $path = $params{'path'};
             my $sum_bytes = $ibyt + $obyt;
             my $sum_packets = $ipkt + $opkt;
             my $proto = '';
-            if($pr =~ /d+/){
+            if( $pr =~ /d+/ ) {
                 $proto = getprotobynumber( $pr );
-            }else{
+            } else {
                 $proto = getprotobyname( lc($pr) );
             }
 

--- a/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
+++ b/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
@@ -381,7 +381,7 @@ my $path = $params{'path'};
             my $sum_bytes = $ibyt + $obyt;
             my $sum_packets = $ipkt + $opkt;
             my $proto = '';
-            if( $pr =~ /d+/ ) {
+            if( $pr =~ /^\d+$/ ) {
                 $proto = getprotobynumber( $pr );
             } else {
                 $proto = getprotobyname( lc($pr) );

--- a/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
+++ b/lib/GRNOC/NetSage/Deidentifier/NetflowImporter.pm
@@ -380,6 +380,12 @@ my $path = $params{'path'};
 
             my $sum_bytes = $ibyt + $obyt;
             my $sum_packets = $ipkt + $opkt;
+            my $proto = '';
+            if($pr =~ /d+/){
+                $proto = getprotobynumber( $pr );
+            }else{
+                $proto = getprotobyname( lc($pr) );
+            }
 
             my $row = {};
             $row->{'type'} = 'flow';
@@ -390,7 +396,7 @@ my $path = $params{'path'};
             $row->{'meta'}->{'src_port'} = $sp;
             $row->{'meta'}->{'dst_ip'} = $da;
             $row->{'meta'}->{'dst_port'} = $dp;
-            $row->{'meta'}->{'protocol'} = getprotobynumber( $pr );
+            $row->{'meta'}->{'protocol'} = $proto;
             $row->{'meta'}->{'sensor_id'} = $sensor;
             $row->{'meta'}->{'instance_id'} = $instance if $instance ne '';
             $row->{'meta'}->{'src_asn'} = $sas;


### PR DESCRIPTION
While testing the pipeline with GPN nfdump was returning a name like TCP for the protocol instead of a number. This patch should handle both cases:

- If it is an int it passes the value to getprotobynum which returns a getprotoent struct (in  C terms). This is the old behavior.
- Otherwise it passes it to getprotobyname to get the same getprotoent struct 