### PR TITLE
Docker Configuration and Documentation Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 conf/systemd/deploy
 ~
 .env
+.DS_Store
 *.pyc
 data

--- a/compose/netsage_shared.xml
+++ b/compose/netsage_shared.xml
@@ -48,4 +48,10 @@
     <vhost>/</vhost>
     <durable>1</durable> <!-- Whether the rabbit queue is 'durable' (don't change this unless you have a reason) -->
   </rabbit_output>
+  
+  <!-- worker settings -->
+  <worker>
+    <cull-enable>1</cull-enable>
+    <cull-ttl>3</cull-ttl>
+  </worker>
 </config>

--- a/conf-logstash/99-outputs.conf
+++ b/conf-logstash/99-outputs.conf
@@ -27,7 +27,7 @@ output {
             host     => "${rabbitmq_output_host:localhost}"
             user     => "${rabbitmq_output_username:guest}"
             password => "${rabbitmq_output_pw:guest}"
-            key           => "netsage_archive_input"
+            key           => "${rabbitmq_output_key:netsage_archive_input}" 
             exchange      => "netsage.direct"
             exchange_type => "direct"
             connection_timeout => 10000

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -45,7 +45,7 @@ If you haven't done so already, copy env.example and update it to match your own
 cp env.example .env
 ```
 
-#### Rabbit 
+### Rabbit 
 This portion is primarily to set the Rabbit MQ server.  Most of the default settings work but whatever values you set
 here should be consistent with the config for the logstash and importer 
 
@@ -85,23 +85,23 @@ rabbitmq_output_key=netsage_archive_input
 
 ## Running the Containers
 
-## Start the Containers
+### Start the Containers
 ```sh
 docker-compose up -d 
 ```
 
-## Stop the Containers
+### Stop the Containers
 ```sh
 docker-compose down
 ```
-## Enter a Container Shell
+### Enter a Container Shell
 ```sh
 docker-compose exec logstash bash     #bash shell in logstash container
 docker-compose exec importer bash     #bash shell in importer container
 docker-compose exec rabbit bash       #bash shell in rabbit container
 ```
 
-## View Container Logs
+### View Container Logs
 ```sh
 docker-compose logs -f              #view logs for all containers 
 docker-compose logs -f logstash     #view logs for logstash container

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -7,22 +7,39 @@ SCIENCE_USER='user' SCIENCE_PWD='secret' ./initialize_docker_data.sh
 ## Build base images
 
 ### Build using Dev Release: 
+If you would like to build the *importer* container using the version of the pipeline scripts found in this GitHub repo then run the following:
 
 ```sh 
 docker-compose -f docker-compose.build.yml build
 ```
 
 ### Build using Production Release: 
-copy the env.template to .env
+You may also build the *importer* container using the RPM published in the GRNOC yum repo as opposed to this source code. **NOTE: The RPM may have older code than is found in this GitHub repository.**
 
-add this entry:
+1. Copy the env.example file to .env
+```sh
+cp env.example .env
+```
+
+2. Add this entry:
+```sh
 RELEASE=true
+```
+
+3. Build the containers
+
+```sh 
+docker-compose -f docker-compose.build.yml build
+```
 
 ## Bring up the stack
 
 ### Environment file.
 
-if you haven't done so already, copy env.template and update it to match your own settings.
+If you haven't done so already, copy env.example and update it to match your own settings:
+```sh
+cp env.example .env
+```
 
 #### Rabbit 
 This portion is primarily to set the Rabbit MQ server.  Most of the default settings work but whatever values you set
@@ -53,12 +70,13 @@ rabbitmq_input_pw=guest
 
 ```
 
-Define the output rabbit Queue.  This can be the docker container or any valid rabbit MQ server.
+Define the output rabbit queue.  This can be the docker container or any valid RabbitMQ server.
 
 ```sh
 rabbitmq_output_host=rabbit
 rabbitmq_output_username=guest
 rabbitmq_output_pw=guest
+rabbitmq_output_key=netsage_archive_input
 ```
 
 ## Bring up the stack.

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -8,16 +8,16 @@ Run the following to download Science Registry and GeoIp data. You may re-run th
 ./initialize_docker_data.sh
 ```
 
-## Build base images
+## Build Base Images
 
-### Build using Dev Release: 
+### Build Using Source Code
 If you would like to build the *importer* container using the version of the pipeline scripts found in this GitHub repo then run the following:
 
 ```sh 
 docker-compose -f docker-compose.build.yml build
 ```
 
-### Build using Production Release: 
+### Build Using Production RPM Release 
 You may also build the *importer* container using the RPM published in the GRNOC yum repo as opposed to this source code. **NOTE: The RPM may have older code than is found in this GitHub repository.**
 
 1. Copy the env.example file to .env
@@ -36,9 +36,9 @@ RELEASE=true
 docker-compose -f docker-compose.build.yml build
 ```
 
-## Bring up the stack
+## Configuring the Containers
 
-### Environment file.
+### Environment File
 
 If you haven't done so already, copy env.example and update it to match your own settings:
 ```sh
@@ -61,11 +61,11 @@ Note the hostname will follow the docker-compose label.  You can rename it if yo
 
 ### Importer 
 
-The importer config is defined in compose/netsage_shared.xml.  If you use different values then the defaults you may want to change them.
+The importer config is defined in compose/netsage_shared.xml.  If you use different values then the defaults you may want to change them/ **NOTE: Changes will require you to rebuild the container**
 
 ### Logstash 
 
-Define the input rabbit Queue.  This should match the Importer output queue
+Define the input rabbit queue.  This should match the importer output queue
 
 ```sh
 rabbitmq_input_host=rabbit
@@ -83,6 +83,8 @@ rabbitmq_output_pw=guest
 rabbitmq_output_key=netsage_archive_input
 ```
 
-## Bring up the stack.
+## Start the Containers
 
+```sh
 docker-compose up -d 
+```

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -18,7 +18,7 @@ docker-compose -f docker-compose.build.yml build
 ```
 
 ### Build Using Production RPM Release 
-You may also build the *importer* container using the RPM published in the GRNOC yum repo as opposed to this source code. **NOTE: The RPM may have older code than is found in this GitHub repository.**
+You may also build the *importer* container using the RPM published in a remote GRNOC yum repo as opposed to your local copy of this source code. **NOTE: The published RPM may install a version of the importer scripts different from what is found in your local copy of this GitHub repository depending on when the RPM was last built and uploaded.**
 
 1. Copy the env.example file to .env
 ```sh

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -1,8 +1,12 @@
 # Docker Setup
 
-## Retrieve Meta data.  Feel free to re-run  to update the data.  Set the correct username/password to match your credentials.
+## Retrieve Enrichment Metadata
 
-SCIENCE_USER='user' SCIENCE_PWD='secret' ./initialize_docker_data.sh
+Run the following to download Science Registry and GeoIp data. You may re-run this at anytime to update these databases.
+
+```sh
+./initialize_docker_data.sh
+```
 
 ## Build base images
 

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -83,8 +83,29 @@ rabbitmq_output_pw=guest
 rabbitmq_output_key=netsage_archive_input
 ```
 
-## Start the Containers
+## Running the Containers
 
+## Start the Containers
 ```sh
 docker-compose up -d 
 ```
+
+## Stop the Containers
+```sh
+docker-compose down
+```
+## Enter a Container Shell
+```sh
+docker-compose exec logstash bash     #bash shell in logstash container
+docker-compose exec importer bash     #bash shell in importer container
+docker-compose exec rabbit bash       #bash shell in rabbit container
+```
+
+## View Container Logs
+```sh
+docker-compose logs -f              #view logs for all containers 
+docker-compose logs -f logstash     #view logs for logstash container
+docker-compose logs -f importer     #view logs for importer container
+docker-compose logs -f rabbit       #view logs for rabbit container
+```
+

--- a/env.example
+++ b/env.example
@@ -14,6 +14,7 @@ rabbitmq_input_pw=guest
 rabbitmq_output_host=rabbit
 rabbitmq_output_username=guest
 rabbitmq_output_pw=guest
+rabbitmq_output_key=netsage_archive_input
 
 ##Build env
 RELEASE=false


### PR DESCRIPTION
This pull request container the following updates I ran across while setting up GPN:

- Enabled culling of old flow data after 3 days. Culling is disabled by default and explicitly called out default in perl code of 3 days.
-  Made `rabbitmq_output_key` a configurable option in .env
- Ignored .DS_Store files on Macs...ok this is not directly related to GPN or Docker but was bugging me


I also updated the documentation.

- Documented new rabbitmq_output_key option
- Fixed references to env.template that should be env.example
- Clarified purpose of RELEASE env variable
- Cleaned-up a lot of the headings
- Added a few more useful `docker-compose` commands
- General clean-up