### PR TITLE
Disable Elastic and Kibana containers by default

### DIFF
--- a/conf-logstash/99-outputs.conf
+++ b/conf-logstash/99-outputs.conf
@@ -40,8 +40,8 @@ output {
        
        #-- If desired: To put results directly into local elasticsearch.
        # elasticsearch {
-       #     hosts => ["127.0.0.1"]           
-       #     index => "test-%{+YYYY.MM.dd}"  
+       #     hosts => ["elasticsearch"]
+       #     index => "netsage_flow-%{+YYYY.MM.dd}"
        # }
 
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,25 +24,23 @@ services:
        volumes:
            - ./data:/data
  #          - ./data/cache:/var/cache/netsage
-  elasticsearch:
-       image: elasticsearch:7.4.2
-       env_file: .env
-       ports:
-         - "9200:9200"
-         - "9300:9300"
   logstash:
        image: netsage/logstash/logstash:builder
        env_file: .env
-       depends_on: 
-        - elasticsearch
        ports:
          - "5044:5044"
        volumes:
            - ./conf-logstash:/usr/share/logstash/pipeline/
            - ./data:/data
            - ./data/cache:/var/cache/netsage
-  kibana:
-       image: kibana:7.4.2
-       env_file: .env
-       ports:
-         - "5601:5601"
+#  elasticsearch:
+#       image: elasticsearch:7.4.2
+#       env_file: .env
+#       ports:
+#         - "9200:9200"
+#         - "9300:9300"
+#  kibana:
+#       image: kibana:7.4.2
+#       env_file: .env
+#       ports:
+#         - "5601:5601"

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -84,20 +84,20 @@ rabbitmq_output_key=netsage_archive_input
 ```
 
 ### Optional: ElasticSearch and Kibana
-You can optionally store flow data locally in an ElasticSearch container and view the data with Kibana. If you are sending results to be stored remotely, this is not necessary. Local storage can be enabled with the following steps:
+You can optionally store flow data locally in an ElasticSearch container and view the data with Kibana. Local storage can be enabled with the following steps:
 
-1.  You can uncomment the elasticsearch and kibana services in docker-compose.yml. 
+1.  Uncomment the elasticsearch and kibana services in docker-compose.yml. 
 
-2. Edit conf-logstash/99-outputs.conf and uncomment the following lines:
+2.  Uncomment the following lines in conf-logstash/99-outputs.conf:
 
 ```
 elasticsearch {
-    hosts => ["127.0.0.1"]           
-    index => "test-%{+YYYY.MM.dd}"  
+    hosts => ["elasticsearch"]
+    index => "netsage_flow-%{+YYYY.MM.dd}"
 }
 ```
 
-3. Comment out the `rabbitmq {...}` block if you do not want to also send to RabbitMQ.
+3. Comment out the `rabbitmq {...}` block in conf-logstash/99-outputs.conf if you do not want to also send logstash output to RabbitMQ.
 
 ## Running the Containers
 

--- a/docs/02_DOCKER.md
+++ b/docs/02_DOCKER.md
@@ -83,6 +83,22 @@ rabbitmq_output_pw=guest
 rabbitmq_output_key=netsage_archive_input
 ```
 
+### Optional: ElasticSearch and Kibana
+You can optionally store flow data locally in an ElasticSearch container and view the data with Kibana. If you are sending results to be stored remotely, this is not necessary. Local storage can be enabled with the following steps:
+
+1.  You can uncomment the elasticsearch and kibana services in docker-compose.yml. 
+
+2. Edit conf-logstash/99-outputs.conf and uncomment the following lines:
+
+```
+elasticsearch {
+    hosts => ["127.0.0.1"]           
+    index => "test-%{+YYYY.MM.dd}"  
+}
+```
+
+3. Comment out the `rabbitmq {...}` block if you do not want to also send to RabbitMQ.
+
 ## Running the Containers
 
 ### Start the Containers

--- a/env.example
+++ b/env.example
@@ -16,5 +16,11 @@ rabbitmq_output_username=guest
 rabbitmq_output_pw=guest
 rabbitmq_output_key=netsage_archive_input
 
+## disable monitoring of logstash to remove local elastic dependency
+XPACK_MONITORING_ENABLED=false
+
+## Logstash log.level setting
+#LOG_LEVEL=debug
+
 ##Build env
 RELEASE=false


### PR DESCRIPTION
By setting `XPACK_MONITORING_ENABLED=false` in .env logstash no longer requires the Elasticsearch container. The requirement stems from the fact that logstash does some self monitoring by default and stores the results in the elastic container. We don't need this so can safely disable.

It's still nice to have the option to enable Elastic and Kibana, but this disables them by default and adds instructions to enable if you need them. 