### PR TITLE
various minor or tested changes for 1.2.8

### DIFF
--- a/conf-logstash/15-sensor-specific-changes.conf
+++ b/conf-logstash/15-sensor-specific-changes.conf
@@ -1,0 +1,15 @@
+# Make changes required for specific sensors
+
+filter {
+
+  if [meta][sensor_id] == "pw-sttl1-1.pacificwave.net" {
+     # Multiply by mirroring-sampling-rate
+     ruby {
+          code => "
+                  event.set('[values][num_bits]', 2048 * event.get('[values][num_bits]').to_i)
+                  event.set('[values][num_packets]', 2048 * event.get('[values][num_packets]').to_i)
+                  "
+          }
+  }
+
+}

--- a/conf-logstash/20-add-id.conf
+++ b/conf-logstash/20-add-id.conf
@@ -19,19 +19,5 @@ filter {
       id                  => 'five-tuple-plus-sensor'
     }
 
-    # Unique id based on the above five-tuple-plus-sensor + start time.
-    # Can be used as the document id in elasticsearch to avoid duplicate records.
-    fingerprint {
-       source => [
-         '[flow_fingerprint]',
-         '[start]'
-       ]
-       concatenate_sources => true
-       method              => 'SHA256'
-       target              => 'es_doc_id'
-       key                 => 'create docid'
-       id                  => 'flow-id-plus-start'
-    }
-
 }
 

--- a/conf-logstash/40-aggregation.conf
+++ b/conf-logstash/40-aggregation.conf
@@ -10,6 +10,8 @@
 # duration is cumulative but counts are not. Sflow ends each flow as it is written out, as one would expect.
 # If only 1 packet is seen, end time will = start time and duration will be 0.
 
+# NOTE: tags added to events before this point in the pipeline aren't kept.
+
 filter {
 
     # TSTAT - tstat only reports complete flows, so no stitching is needed!
@@ -76,7 +78,6 @@ filter {
 
             # save info from the first subflow
             # values will be updated as we stitch on other flows
-            map['type']   ||= event.get('type')              # type will be 'flow' (vs macy, etc)
             map['meta']   ||= event.get('meta')
             map['values'] ||= event.get('values')
 

--- a/conf-logstash/53-caida-org.conf
+++ b/conf-logstash/53-caida-org.conf
@@ -36,7 +36,7 @@ filter {
     if [meta][dst_organization] == "0" or [meta][dst_asn] == -1 {
         mutate {
             id => "53-4"
-            replace => { "[meta][src_organization]" => "Unknown" }
+            replace => { "[meta][dst_organization]" => "Unknown" }
         }
     }
 

--- a/conf-logstash/55-member-orgs.conf
+++ b/conf-logstash/55-member-orgs.conf
@@ -2,6 +2,7 @@
 # "member organizations" which have been assigned certain IP blocks by a parent org.
 # Member names and IP ranges should be in *-members-list.rb files, eg, ilight-members-list.rb.
 # Lookups are done only for the ASNs listed in *-members-list.rb (as integer array).
+# The first member netblock encountered that contains the IP is the one used to get the org name.
 
 filter {
 

--- a/conf-logstash/90-additional-fields.conf
+++ b/conf-logstash/90-additional-fields.conf
@@ -49,4 +49,18 @@ filter {
              }
         }
 
+        # Unique id based on the meta.id (five-tuple-plus-sensor) + start time.
+        # Can be used as the document id in elasticsearch to avoid duplicate records (for sflow only).
+        fingerprint {
+           source => [
+             '[flow_fingerprint]',
+             '[start]'
+           ]
+           concatenate_sources => true
+           method              => 'SHA256'
+           target              => 'es_doc_id'
+           key                 => 'create docid'
+           id                  => 'flow-id-plus-start'
+        }
+
 }

--- a/conf-logstash/95-cleanup.conf
+++ b/conf-logstash/95-cleanup.conf
@@ -1,6 +1,6 @@
 filter {
 
-    # make sure this has been renamed for backwards-compatability (in case aggregation conf has not been used)
+    # make sure this has been renamed (in case aggregation conf has not been used)
     if [flow_fingerprint] {
       mutate {
         id => "95-1"
@@ -26,20 +26,6 @@ filter {
       remove_field => "[interval]"
       remove_field => "[meta][src_ifindex]"
       remove_field => "[meta][dst_ifindex]"
-      remove_field => "[type]"
     }
  
-    # type conversions so elasticsearch guesses correctly
-    mutate {
-      id => "95-5"
-      convert => {
-          "[meta][scireg][src][latitude]"      => "float"
-          "[meta][scireg][dst][latitude]"      => "float"
-          "[meta][scireg][src][longitude]"     => "float"
-          "[meta][scireg][dst][longitude]"     => "float"
-          "[meta][src_port]"                   => "integer"
-          "[meta][dst_port]"                   => "integer"
-        }
-    }
-
 }

--- a/conf-logstash/99-output-multiline-json.conf.disabled
+++ b/conf-logstash/99-output-multiline-json.conf.disabled
@@ -7,7 +7,7 @@ output {
     file {
         path => "/testdir/test-data.json"
  	codec => line {format => 
-        '{ "start":%{start}, "end":%{end}, "type":"%{type}", "interval":%{interval},
+        '{ "start":%{start}, "end":%{end},  "interval":%{interval},
            "meta":{ "sensor_id":"%{[meta][sensor_id]}", "protocol":"%{[meta][protocol]}", "flow_type":"%{[meta][flow_type]}", 
            "src_ip":"%{[meta][src_ip]}", "src_port":%{[meta][src_port]}, "src_asn":%{[meta][src_asn]}, "src_ifindex":%{[meta][src_ifindex]},
            "dst_ip":"%{[meta][dst_ip]}", "dst_port":%{[meta][dst_port]}, "dst_asn":%{[meta][dst_asn]}, "dst_ifindex":%{[meta][dst_ifindex]} },

--- a/conf-logstash/support/sensor_groups.json
+++ b/conf-logstash/support/sensor_groups.json
@@ -20,5 +20,6 @@
     "^.*TACC.*": "TACC",
     "^.*tacc.*": "TACC",
     "^.*TransPAC.*": "TransPAC",
-    "^.*UCAR.*": "UCAR"
+    "^.*UCAR.*": "UCAR",
+    "^Sun Corridor.*": "Sun Corridor"
 }

--- a/conf-logstash/support/sensor_types.json
+++ b/conf-logstash/support/sensor_types.json
@@ -18,5 +18,6 @@
     "^i-Light.*$": "Regional Network",
     "^PennREN.*$": "Regional Network",
     "^tacc_sflows$": "Regional Network",
-    "^SANReN.*$": "Regional Network"
+    "^SANReN.*$": "Regional Network",
+    "^Sun Corridor.*$": "Regional Network"
 }

--- a/grnoc-netsage-deidentifier.spec
+++ b/grnoc-netsage-deidentifier.spec
@@ -188,6 +188,7 @@ rm -rf $RPM_BUILD_ROOT
 /var/cache/netsage/
 
 %post
+echo " "
 echo "-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*"
 echo "AFTER UPGRADING..."
 echo " "
@@ -203,4 +204,5 @@ echo " *      and be sure logstash configs are specified by *.conf in the right 
 echo " "
 echo " *  [Re]start logstash, netsage netflow importers (and netsage flow filters for cenic sensors only) "
 echo "-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*"
+echo " "
 


### PR DESCRIPTION
        ▪	Moved es_doc_id  from 20 to 90
	▪	Added Sun Corridor regexes to support/sensor_types and sensor_groups files.
	▪	Fixed typo in 53-caida-org.conf which affected src org for multicast flows or those without a dst asn
	▪	Added 15-sensor-specific-changes.conf:
		with multiplication by 2048 for pw-sttl1-1.pacificwave.net
	▪	Removed unneeded field type conversions in 95-cleanup.conf
	▪	added note in 55 that the first member org netblock that contains the IP is the one used.
	▪	Took "type" (=flow) out of aggregation map in 40, and don't need to remove in 95-cleanup.conf, or show in 99-output-multiline-json.conf.disabled
